### PR TITLE
Set aac as default audio codec

### DIFF
--- a/HLS-Stream-Creator.sh
+++ b/HLS-Stream-Creator.sh
@@ -51,7 +51,7 @@ NUMTHREADS=${NUMTHREADS:-"0"}
 VIDEO_CODEC=${VIDEO_CODEC:-"libx264"}
 
 # Audio codec for the output video. Will be used as an value for the -acodec argument
-AUDIO_CODEC=${AUDIO_CODEC:-"libfdk_aac"}
+AUDIO_CODEC=${AUDIO_CODEC:-"aac"}
 
 # Additional flags for ffmpeg
 FFMPEG_FLAGS=${FFMPEG_FLAGS:-""}


### PR DESCRIPTION
Advanced Audio Coding (AAC) encoder is the recommended and default FFMPEG encoder.

Reference: https://www.ffmpeg.org/ffmpeg-codecs.html#aac