### PR TITLE
Make OUTPUT_DIRECTORY play nicely with -S & -o

### DIFF
--- a/HLS-Stream-Creator.sh
+++ b/HLS-Stream-Creator.sh
@@ -365,6 +365,7 @@ then
 	fi
 
 	SEGMENT_DIRECTORY+="/"
+	OUTPUT_DIRECTORY+="/"
 fi
 
 # Set the bitrate


### PR DESCRIPTION
The command:
`./segment.sh -i video.mov -s 4 -b 512 -t video -p video -S partials -o streams` would fail without this fix, as it would try to access streamspartials (notice the missing directory-separator).

and you would have to append the slash in your config and make the command look like this:
`./segment.sh -i video.mov -s 4 -b 512 -t video -p video -S partials -o streams/`

This fixes the issue, and you can now omit the last slash in the -o flag.