### PR TITLE
modify insert key name to m3u8 file.

### DIFF
--- a/HLS-Stream-Creator.sh
+++ b/HLS-Stream-Creator.sh
@@ -255,7 +255,7 @@ function encrypt(){
     for manifest in ${OUTPUT_DIRECTORY}/*.m3u8
     do
         # Insert the KEY at the 5'th line in the m3u8 file
-        sed -i "5i #EXT-X-KEY:METHOD=AES-128,URI="${KEY_PREFIX}${KEY_NAME}.key "$manifest"
+        sed -i "5i #EXT-X-KEY:METHOD=AES-128,URI=\""${KEY_PREFIX}${KEY_NAME}.key"\"" "$manifest"
     done
 }
 


### PR DESCRIPTION
Hi
When i use make m3u8 file with encrypt.

If do not have double quotes around the key file name, it will not play on iOS.
(AOS is well play without double quotes or with double quotes.)

So I added double quotes around the key name.

Thanks.