### PR TITLE
Add input options as an environmental variable

### DIFF
--- a/HLS-Stream-Creator.sh
+++ b/HLS-Stream-Creator.sh
@@ -55,6 +55,7 @@ AUDIO_CODEC=${AUDIO_CODEC:-"aac"}
 
 # Additional flags for ffmpeg
 FFMPEG_FLAGS=${FFMPEG_FLAGS:-""}
+FFMPEG_INPUT_FLAGS=${FFMPEG_INPUT_FLAGS:-""}
 
 # If the input is a live stream (i.e. linear video) this should be 1
 LIVE_STREAM=${LIVE_STREAM:-0}
@@ -156,7 +157,8 @@ if $TWOPASS; then
 		/dev/null
 fi
 
-$FFMPEG -i "$infile" \
+$FFMPEG $FFMPEG_INPUT_FLAGS \
+    -i "$infile" \
     $PASSVAR \
     -y \
     -vcodec "$VIDEO_CODEC" \
@@ -280,7 +282,7 @@ function encrypt(){
 }
 
 # This is used internally, if the user wants to specify their own flags they should be
-# setting FFMPEG_FLAGS
+# setting FFMPEG_FLAGS or FFMPEG_INPUT_FLAGS
 FFMPEG_ADDITIONAL=''
 LIVE_SEGMENT_COUNT=0
 IS_FIFO=0

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ There are few environment variables which can control the ffmpeg behaviour.
 * `AUDIO_CODEC` - Encoder for the audio streams. Examples: _aac_, _libfdk_acc_, _mp3_, _libfaac_
 * `NUMTHREADS` - A number which will be passed to the `-threads` argument of ffmpeg. Newer ffmpegs with modern libx264 encoders will use the optimal number of threads by default.
 * `FFMPEG_FLAGS` - Additional flags for ffmpeg. They will be passed without any modification.
+* `FFMPEG_INPUT_FLAGS` - Additional flags for ffmpeg which apply to the input file only. They will also be passed without any modification.
 
 Example usage:
 


### PR DESCRIPTION
By adding an input option, it will allow the script to work for hardware accelerated decoding, which requires `-hwaccel` as an option for the input file. For example, I can manually run something like `ffmpeg -hwaccel cuvid -vcodec h264_cuvid -i input.mp4 -y -vcodec h264_nvenc -acodec aac -hls_list_size 0 output.m3u8` so that my CPU only has to do the audio encoding. Everything else is offloaded to the GPU.

Also, feel free to modify the README if it sounds too repetitive.